### PR TITLE
Avoid sudo pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ react %>% predict("Happy Mother's Day from the Chicago Cubs!")
 For Python, reactionrnn can be installed [from pypi](https://pypi.python.org/pypi/reactionrnn) via `pip`:
 
 ```
-sudo pip3 install reactionrnn
+python3 -m pip install reactionrnn
 ```
 
+You may need to create a venv (`python3 -m venv <path>`) first
 For R, you can install reactionrnn from this GitHub repo with devtools (working on resolving issues to get package on CRAN):
 
 ```


### PR DESCRIPTION
Using sudo with pip will break the permissions in the user/global packages directory