### PR TITLE
[Python] set encoding strictly to utf8

### DIFF
--- a/reactionrnn/reactionrnn.py
+++ b/reactionrnn/reactionrnn.py
@@ -25,7 +25,7 @@ class reactionrnn:
             vocab_path = resource_filename(__name__,
                                            'reactionrnn_vocab.json')
 
-        with open(vocab_path, 'r') as json_file:
+        with open(vocab_path, 'r', encoding="utf8") as json_file:
             self.vocab = json.load(json_file)
 
         self.tokenizer = Tokenizer(filters='', char_level=True)


### PR DESCRIPTION
Set the encoding for loading JSON file strictly to UTF8 to fix a bug where a character cannot be decoded in the cp encoding (Note that this was only dont in the Python version as I don't know R